### PR TITLE
fix bug that prevents deleting some items

### DIFF
--- a/src/module/item/item.js
+++ b/src/module/item/item.js
@@ -32,7 +32,7 @@ export class DemonlordItem extends Item {
     if (!(this?.parent instanceof DemonlordActor)) return Promise.resolve()
 
     // Delete Active effects with this origin
-    let aes = this.parent.effects.filter(ae => ae.data?.origin.includes(this.id))
+    let aes = this.parent.effects.filter(ae => ae.data?.origin?.includes(this.id))
     for (const ae of aes) {
       try {
         await ae.delete({ parent: this.parent })


### PR DESCRIPTION
In some situations ae.data.origin can be undefined so the call crashes - preventing an item to be deleted. Adding a `?` after `origin` fixes this and handles the situation the same way it's handled for `data` missing.